### PR TITLE
Fix type error when concatenating None

### DIFF
--- a/gptfuzzer/fuzzer/mutator.py
+++ b/gptfuzzer/fuzzer/mutator.py
@@ -214,6 +214,6 @@ class MutateRandomSinglePolicy(MutatePolicy):
         mutator = random.choice(self.mutators)
         results = mutator.mutate_single(prompt_node.prompt)
         if self.concatentate:
-            results = [result + prompt_node.prompt  for result in results]
+            results = [result or '' + prompt_node.prompt for result in results]
 
         return [PromptNode(self.fuzzer, result, parent=prompt_node, mutator=mutator) for result in results]


### PR DESCRIPTION
Sometimes the mutator returns a result =None. In such case, concatenating a result=None with the prompt string raises an exception (TypeError, see below)

```
Traceback (most recent call last):
...
  File "...", line 53, in run
    mutated_results = self.mutate_policy.mutate_single(seed)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.11/site-packages/gptfuzzer/fuzzer/mutator.py", line 216, in mutate_single
    results = [result + prompt_node.prompt for result in results]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.11/site-packages/gptfuzzer/fuzzer/mutator.py", line 216, in <listcomp>
    results = [result + prompt_node.prompt for result in results]
               ~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
This PR fixes the TypeError concatenating the prompt string with either `result` value (if not None) or an empty string (if `result` is =None)